### PR TITLE
Upgrade Dependencies to Symfony 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,17 +26,19 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "behat/behat": "~3",
-        "symfony/stopwatch": "~3"
+        "behat/behat": "^3.5",
+        "symfony/stopwatch": "^3.0 || ^4.3",
+        "symfony/dependency-injection": "^3.0 || ^4.3",
+        "symfony/event-dispatcher": "^3.0 || ^4.3",
+        "symfony/console": "^3.0 || ^4.3"
     },
     "require-dev": {
-        "phploc/phploc": "~3",
-        "squizlabs/php_codesniffer": "~3"
+        "squizlabs/php_codesniffer": "~3",
+        "phploc/phploc": "^5.0"
     },
     "autoload": {
         "psr-4": {
             "IMT\\BehatProfilingExtension\\": "src/"
         }
-    },
-    "minimum-stability": "dev"
+    }
 }


### PR DESCRIPTION
Wanted to use this profiler, but there is a hard dependency on Symfony 3 components. This change allows Symfony 4 components to also be used (required upgrade to phploc). There were no BC-changes so no code needs to be changed.

Additionally added explicit requirements on the components used and removed the `"minimum-stability": "dev"` which seemed unnecessary.